### PR TITLE
refactor: transfer to grafana/xk6-faker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,4 @@ jobs:
         id: build
         uses: szkiba/xk6bundler@v0
         with:
-          with: github.com/szkiba/xk6-faker=/github/workspace
+          with: github.com/grafana/xk6-faker=/github/workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: build
         uses: szkiba/xk6bundler@v0
         with:
-          with: github.com/szkiba/xk6-faker=/github/workspace
+          with: github.com/grafana/xk6-faker=/github/workspace
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: szkiba/xk6-faker
+          slug: grafana/xk6-faker
 
       - name: Full Test
         if: ${{ matrix.platform == 'ubuntu-latest' }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-[![API Reference](https://img.shields.io/badge/API-reference-blue?logo=readme&logoColor=lightgray)](https://ivan.szkiba.hu/xk6-faker)
-[![GitHub Release](https://img.shields.io/github/v/release/szkiba/xk6-faker)](https://github.com/szkiba/xk6-faker/releases/)
-[![Go Report Card](https://goreportcard.com/badge/github.com/szkiba/xk6-faker)](https://goreportcard.com/report/github.com/szkiba/xk6-faker)
-[![GitHub Actions](https://github.com/szkiba/xk6-faker/actions/workflows/test.yml/badge.svg)](https://github.com/szkiba/xk6-faker/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/szkiba/xk6-faker/graph/badge.svg?token=RDJNHP8NFP)](https://codecov.io/gh/szkiba/xk6-faker)
-![k6 registry](https://registry.k6.io/module/github.com/szkiba/xk6-faker/badge.svg)
-![GitHub Downloads](https://img.shields.io/github/downloads/szkiba/xk6-faker/total)
+[![API Reference](https://img.shields.io/badge/API-reference-blue?logo=readme&logoColor=lightgray)](https://faker.x.k6.io)
+[![GitHub Release](https://img.shields.io/github/v/release/grafana/xk6-faker)](https://github.com/grafana/xk6-faker/releases/)
+[![Go Report Card](https://goreportcard.com/badge/github.com/grafana/xk6-faker)](https://goreportcard.com/report/github.com/grafana/xk6-faker)
+[![GitHub Actions](https://github.com/grafana/xk6-faker/actions/workflows/test.yml/badge.svg)](https://github.com/grafana/xk6-faker/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/grafana/xk6-faker/graph/badge.svg?token=RDJNHP8NFP)](https://codecov.io/gh/grafana/xk6-faker)
+![GitHub Downloads](https://img.shields.io/github/downloads/grafana/xk6-faker/total)
 
 # xk6-faker
 
@@ -14,7 +13,7 @@ Although there are several good JavaScript fake data generators, using these in 
 
 For convenience, the xk6-faker API resembles the popular [Faker.js](https://fakerjs.dev/). The category names and the generator function names are often different (due to the [underlying go faker library](https://github.com/brianvoe/gofakeit)), but the usage pattern is similar.
 
-Check out the API documentation [here](https://ivan.szkiba.hu/xk6-faker). The TypeScript declaration file can be downloaded from [here](https://ivan.szkiba.hu/xk6-faker/index.d.ts).
+Check out the API documentation [here](https://faker.x.k6.io). The TypeScript declaration file can be downloaded from [here](https://faker.x.k6.io/index.d.ts).
 
 ## Usage
 
@@ -64,21 +63,21 @@ export default function () {
 // output: Josiah
 ```
 
-The [examples](https://github.com/szkiba/xk6-faker/blob/master/examples) directory contains examples of how to use the xk6-faker extension. A k6 binary containing the xk6-faker extension is required to run the examples.
+The [examples](https://github.com/grafana/xk6-faker/blob/master/examples) directory contains examples of how to use the xk6-faker extension. A k6 binary containing the xk6-faker extension is required to run the examples.
 
 > [!IMPORTANT]
 > If the search path also contains the k6 command, don't forget to specify which k6 you want to run (for example `./k6`).
 
 ## Download
 
-You can download pre-built k6 binaries from the [Releases](https://github.com/szkiba/xk6-faker/releases/) page.
+You can download pre-built k6 binaries from the [Releases](https://github.com/grafana/xk6-faker/releases/) page.
 
 **Build**
 
 The [xk6](https://github.com/grafana/xk6) build tool can be used to build a k6 that will include xk6-faker extension:
 
 ```bash
-$ xk6 build --with github.com/szkiba/xk6-faker@latest
+$ xk6 build --with github.com/grafana/xk6-faker@latest
 ```
 
 For more build options and how to use xk6, check out the [xk6 documentation](https://github.com/grafana/xk6).
@@ -87,4 +86,4 @@ For more build options and how to use xk6, check out the [xk6 documentation](htt
 
 If you find the xk6-faker extension useful, please star the repo. The number of stars will determine the time allocated for maintenance.
 
-[![Stargazers over time](https://starchart.cc/szkiba/xk6-faker.svg?variant=adaptive)](https://starchart.cc/szkiba/xk6-faker)
+[![Stargazers over time](https://starchart.cc/grafana/xk6-faker.svg?variant=adaptive)](https://starchart.cc/grafana/xk6-faker)

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/grafana/sobek"
+	"github.com/grafana/xk6-faker/faker"
 	"github.com/stretchr/testify/require"
-	"github.com/szkiba/xk6-faker/faker"
 )
 
 func Test_Constructor(t *testing.T) {

--- a/faker/lookup_test.go
+++ b/faker/lookup_test.go
@@ -3,8 +3,8 @@ package faker_test
 import (
 	"testing"
 
+	"github.com/grafana/xk6-faker/faker"
 	"github.com/stretchr/testify/require"
-	"github.com/szkiba/xk6-faker/faker"
 )
 
 func TestGetFuncLookups(t *testing.T) {

--- a/functions-test.js
+++ b/functions-test.js
@@ -279,7 +279,7 @@ export default function () {
   });
   group('time', ()=> {
     check(faker.time.date("RFC3339"), { 'time.date("RFC3339")': checker });
-    check(faker.time.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd"), { 'time.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd")': checker });
+    check(faker.time.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd"), { 'time.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd")': checker });
     check(faker.time.day(), { 'time.day()': checker });
     check(faker.time.futureTime(), { 'time.futureTime()': checker });
     check(faker.time.hour(), { 'time.hour()': checker });
@@ -523,8 +523,8 @@ export default function () {
     check(faker.call("databaseError"), { 'call("databaseError")': checker });
     check(faker.zen.date("RFC3339"), { 'zen.date("RFC3339")': checker });
     check(faker.call("date","RFC3339"), { 'call("date","RFC3339")': checker });
-    check(faker.zen.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd"), { 'zen.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd")': checker });
-    check(faker.call("dateRange","1970-01-01","2024-09-04","yyyy-MM-dd"), { 'call("dateRange","1970-01-01","2024-09-04","yyyy-MM-dd")': checker });
+    check(faker.zen.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd"), { 'zen.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd")': checker });
+    check(faker.call("dateRange","1970-01-01","2024-09-05","yyyy-MM-dd"), { 'call("dateRange","1970-01-01","2024-09-05","yyyy-MM-dd")': checker });
     check(faker.zen.day(), { 'zen.day()': checker });
     check(faker.call("day"), { 'call("day")': checker });
     check(faker.zen.demonstrativeAdjective(), { 'zen.demonstrativeAdjective()': checker });

--- a/functions.json
+++ b/functions.json
@@ -862,7 +862,7 @@
         "display": "End Date",
         "type": "string",
         "optional": false,
-        "default": "2024-09-04",
+        "default": "2024-09-05",
         "options": null,
         "description": "End date time string"
       },

--- a/functions_test.go
+++ b/functions_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
+	"github.com/grafana/xk6-faker/faker"
+	"github.com/grafana/xk6-faker/module"
 	"github.com/stretchr/testify/require"
-	"github.com/szkiba/xk6-faker/faker"
-	"github.com/szkiba/xk6-faker/module"
 	"go.k6.io/k6/cmd"
 	"go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/js/modulestest"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/szkiba/xk6-faker
+module github.com/grafana/xk6-faker
 
 go 1.21
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2008,7 +2008,7 @@ export declare interface Finance {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "FRS4BL2MVY67"
+   * "PGS4BL2MVY68"
    * ```
    */
   isin(): string;
@@ -4618,7 +4618,7 @@ export declare interface Person {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * {"unless":["these"],"army":["congolese"],"party":["far"],"theirs":["still"],"instead":["trip"],"here":["computer"],"mine":["how"],"riches":["choir"],"whichever":["keep"],"that":["none"]}
+   * {"army":["congolese"],"riches":["choir"],"theirs":["still"],"that":["none"],"unless":["these"],"party":["far"],"instead":["trip"],"here":["computer"],"mine":["how"],"whichever":["keep"]}
    * ```
    */
   teams(people: string[], teams: string[]): Record<string, Array<string>>;
@@ -4997,7 +4997,7 @@ export declare interface Time {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "1947-09-07T20:35:43Z"
+   * "2011-10-23T18:10:11Z"
    * ```
    */
   date(format: string): string;
@@ -5015,13 +5015,13 @@ export declare interface Time {
    *let faker = new Faker(11)
    *
    *export default function () {
-   *  console.log(faker.time.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd"))
+   *  console.log(faker.time.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd"))
    *}
    *
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "1985-07-29"
+   * "1988-03-03"
    * ```
    */
   dateRange(startdate: string, enddate: string, format: string): string;
@@ -5063,7 +5063,7 @@ export declare interface Time {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "2024-09-05T04:42:18.111798938+02:00"
+   * "2024-09-05T22:35:15.223243185+02:00"
    * ```
    */
   futureTime(): string;
@@ -5189,7 +5189,7 @@ export declare interface Time {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "2024-09-04T08:42:18.111955114+02:00"
+   * "2024-09-05T02:35:15.223523755+02:00"
    * ```
    */
   pastTime(): string;
@@ -8468,7 +8468,7 @@ export declare interface Zen {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "1935-04-20T05:34:10Z"
+   * "1935-04-15T22:34:18Z"
    * ```
    */
   date(format: string): string;
@@ -8486,13 +8486,13 @@ export declare interface Zen {
    *let faker = new Faker(11)
    *
    *export default function () {
-   *  console.log(faker.zen.dateRange("1970-01-01","2024-09-04","yyyy-MM-dd"))
+   *  console.log(faker.zen.dateRange("1970-01-01","2024-09-05","yyyy-MM-dd"))
    *}
    *
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "1985-12-31"
+   * "2016-07-25"
    * ```
    */
   dateRange(startdate: string, enddate: string, format: string): string;
@@ -9150,7 +9150,7 @@ export declare interface Zen {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "2024-09-05T04:42:18.116635977+02:00"
+   * "2024-09-05T22:35:15.227971018+02:00"
    * ```
    */
   futureTime(): string;
@@ -10062,7 +10062,7 @@ export declare interface Zen {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "MFS4BL2MVY62"
+   * "CZS4BL2MVY60"
    * ```
    */
   isin(): string;
@@ -11556,7 +11556,7 @@ export declare interface Zen {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * "2024-09-04T08:42:18.119414026+02:00"
+   * "2024-09-05T02:35:15.231901632+02:00"
    * ```
    */
   pastTime(): string;
@@ -12763,7 +12763,7 @@ export declare interface Zen {
    *```
    * **Output** (formatted as JSON value)
    *```json
-   * {"whichever":["keep"],"army":["congolese"],"party":["far"],"mine":["how"],"instead":["trip"],"here":["computer"],"that":["none"],"unless":["these"],"riches":["choir"],"theirs":["still"]}
+   * {"riches":["choir"],"theirs":["still"],"here":["computer"],"unless":["these"],"army":["congolese"],"party":["far"],"instead":["trip"],"mine":["how"],"whichever":["keep"],"that":["none"]}
    * ```
    */
   teams(people: string[], teams: string[]): Record<string, Array<string>>;

--- a/module/module.go
+++ b/module/module.go
@@ -4,7 +4,7 @@ package module
 import (
 	"strconv"
 
-	"github.com/szkiba/xk6-faker/faker"
+	"github.com/grafana/xk6-faker/faker"
 	"go.k6.io/k6/js/modules"
 )
 

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -3,8 +3,8 @@ package module_test
 import (
 	"testing"
 
+	"github.com/grafana/xk6-faker/module"
 	"github.com/stretchr/testify/require"
-	"github.com/szkiba/xk6-faker/module"
 	"go.k6.io/k6/js/modulestest"
 )
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xk6-faker",
   "version": "0.3.0",
   "description": "Random fake data generator for k6",
-  "repository": "github:szkiba/xk6-faker",
+  "repository": "github:grafana/xk6-faker",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@types/k6": "^0.49.1",

--- a/register.go
+++ b/register.go
@@ -2,7 +2,7 @@
 package faker
 
 import (
-	"github.com/szkiba/xk6-faker/module"
+	"github.com/grafana/xk6-faker/module"
 
 	"go.k6.io/k6/js/modules"
 )

--- a/releases/v0.4.0.md
+++ b/releases/v0.4.0.md
@@ -1,0 +1,11 @@
+xk6-faker `v0.4.0` is here 🎉!
+
+## Transfer to grafana/xk6-faker
+
+The `szkiba/xk6-faker` repository has been transferred to the `grafana` GitHub organization: `grafana/xk6-faker`
+
+New location for API documentation: https://faker.x.k6.io
+
+The transfer involved several renamings (go module, git remote, etc.).
+
+**This release does not contain any other changes.**

--- a/tools/codegen/gents.go
+++ b/tools/codegen/gents.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/grafana/sobek"
+	"github.com/grafana/xk6-faker/faker"
+	"github.com/grafana/xk6-faker/module"
 	"github.com/iancoleman/strcase"
-	"github.com/szkiba/xk6-faker/faker"
-	"github.com/szkiba/xk6-faker/module"
 )
 
 //go:embed prolog.d.ts

--- a/tools/codegen/lookup.go
+++ b/tools/codegen/lookup.go
@@ -5,7 +5,7 @@ package main
 import (
 	"strings"
 
-	"github.com/szkiba/xk6-faker/faker"
+	"github.com/grafana/xk6-faker/faker"
 
 	"github.com/brianvoe/gofakeit/v6"
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "categorizeByGroup": false,
     "visibilityFilters": {},
     "navigationLinks": {
-      "GitHub": "https://github.com/szkiba/xk6-faker"
+      "GitHub": "https://github.com/grafana/xk6-faker"
     }
   },
   "compilerOptions": {


### PR DESCRIPTION
## Transfer to grafana/xk6-faker

The `szkiba/xk6-faker` repository has been transferred to the `grafana` GitHub organization: `grafana/xk6-faker`

New location for API documentation: https://faker.x.k6.io

The transfer involved several renamings (go module, git remote, etc.).

**This release does not contain any other changes.**