### PR TITLE
use Release workflow from grafana/k6-extension-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,58 +1,10 @@
 name: Release
+
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*.*.*"]
 
 jobs:
   release:
-    name: Bundle xk6 extensions
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build
-        id: build
-        uses: szkiba/xk6bundler@v0
-        with:
-          with: github.com/grafana/xk6-faker=/github/workspace
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*.tar.gz
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: ./${{ steps.build.outputs.dockerdir }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    name: Release
+    uses: grafana/k6-extension-workflows/.github/workflows/release.yml@v0.2.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   validate:
     name: Validate
-    uses: grafana/k6-extension-workflows/.github/workflows/validate.yml@v0.1.0
+    uses: grafana/k6-extension-workflows/.github/workflows/validate.yml@v0.2.0


### PR DESCRIPTION
Use the Release workflow from the [grafana/k6-extension-workflows](https://github.com/grafana/k6-extension-workflows ) repository to attach release artifact (precompiled k6 binaries) to releases.