### PR TITLE
prepare v0.4.1

### DIFF
--- a/releases/v0.4.1.md
+++ b/releases/v0.4.1.md
@@ -1,0 +1,3 @@
+xk6-faker `v0.4.1` is here 🎉!
+
+This is a maintenance release, the k6 version has been updated to v0.56.0. There are no other changes in this release.


### PR DESCRIPTION
This is a maintenance release, the k6 version has been updated to v0.56.0. There are no other changes in this release.
